### PR TITLE
Feature/ab#59 load project templates from backend in app editor

### DIFF
--- a/webclient/app/src/app/pages/appEditor/sections/templateSection/TemplateSection.jsx
+++ b/webclient/app/src/app/pages/appEditor/sections/templateSection/TemplateSection.jsx
@@ -18,22 +18,6 @@ function TemplateSection(props) {
     const appTemplateRest = useMemo(() => new AppTemplateRest(), []);
     const {t} = useTranslation();
 
-    /* const templates = [
-         {
-             id: 1,
-             name: "Standard Runtime",
-             description: "Das ist eine lange Beschreibung der Standard-Runtime",
-             image: Image
-         },
-         {
-             id: 2,
-             name: "Andere Runtime",
-             description: "Das ist eine lange Beschreibung der Standard-Runtime",
-             image: Image
-         },
-     ]*/
-
-
     const loadAppTemplates = useCallback(() => {
         setTemplates(null);
         setAppTemplatesError(null);

--- a/webclient/app/src/app/pages/appEditor/sections/templateSection/TemplateSection.jsx
+++ b/webclient/app/src/app/pages/appEditor/sections/templateSection/TemplateSection.jsx
@@ -1,30 +1,69 @@
-import React from "react";
+import React, {useCallback, useEffect, useMemo, useState} from "react";
 import {Container, Grid} from "@mui/material";
-import Image from "../../../../assets/images/logo.png"
 import AppTemplateSelectCard from "../../../../commons/appTemplateSelectCard/AppTemplateSelectCard";
+import AppTemplateRest from "../../../../services/AppTemplateRest";
+import LoadingSpinner from "../../../../commons/loadingSpinner/LoadingSpinner";
+import Statement from "../../../../commons/statement/Statement";
+import {Clear} from "@mui/icons-material";
+import {useTranslation} from "react-i18next";
 
 
 function TemplateSection(props) {
 
     const {onChange, value} = props;
 
-    const templates = [
-        {
-            id: 1,
-            name: "Standard Runtime",
-            description: "Das ist eine lange Beschreibung der Standard-Runtime",
-            image: Image
-        },
-        {
-            id: 2,
-            name: "Andere Runtime",
-            description: "Das ist eine lange Beschreibung der Standard-Runtime",
-            image: Image
-        },
-    ]
+
+    const [templates, setTemplates] = useState(null);
+    const [appTemplatesError, setAppTemplatesError] = useState(null);
+    const appTemplateRest = useMemo(() => new AppTemplateRest(), []);
+    const {t} = useTranslation();
+
+    /* const templates = [
+         {
+             id: 1,
+             name: "Standard Runtime",
+             description: "Das ist eine lange Beschreibung der Standard-Runtime",
+             image: Image
+         },
+         {
+             id: 2,
+             name: "Andere Runtime",
+             description: "Das ist eine lange Beschreibung der Standard-Runtime",
+             image: Image
+         },
+     ]*/
+
+
+    const loadAppTemplates = useCallback(() => {
+        setTemplates(null);
+        setAppTemplatesError(null);
+        appTemplateRest.findAll().then(allAppsResponse => {
+            setTemplates(allAppsResponse.data);
+        }).catch(allAppsResponseError => {
+            setAppTemplatesError(allAppsResponseError.response)
+        })
+    }, [appTemplateRest, setTemplates, setAppTemplatesError])
+
+
+    useEffect(() => {
+        loadAppTemplates()
+    }, [loadAppTemplates]);
 
     function handleSelection(template) {
         onChange(template)
+    }
+
+    if (!templates) {
+        return <LoadingSpinner message={t("appTemplates.loading")}/>;
+    }
+
+    if (appTemplatesError) {
+        return <Statement
+            message={t("appTemplates.loading.error")}
+            icon={<Clear/>}
+            actionMessage={t("button.retry")}
+            onActionClick={loadAppTemplates}
+        />;
     }
 
     return (

--- a/webclient/app/src/localization/translations-de-DE.js
+++ b/webclient/app/src/localization/translations-de-DE.js
@@ -103,6 +103,8 @@ const translationsDeDE = {
     "generalSection.enterInformation": "Bitte gib als ersten Schritt die allgemeinen Informationen zu deiner App ein.",
     "generalSection.clickNext": "Klicke dann auf Weiter auf der oberen rechten Seite.",
 
+    "templateSection.loading": "Templates werden geladen...",
+    "templateSection.loading.error": "Templates konnten nicht geladen werden",
 
     "default.welcome": "Herzlich Willkommen",
     "default.error.403.title": "Fehlende Berechtigungen",

--- a/webclient/app/src/localization/translations-en-EN.js
+++ b/webclient/app/src/localization/translations-en-EN.js
@@ -86,7 +86,7 @@ const translationsEnEN = {
     "appTemplateAuthDialog.title": "Login Git Template Repository",
     "appTemplateAuthDialog.user": "User",
     "appTemplateAuthDialog.password": "Password",
-  
+
     "generalSection.hello": "Hello!",
     "generalSection.enterInformation": "Please enter as a first step generation information to your app.",
     "generalSection.clickNext": "Afterwards, please click next on the upper right side to continue.",
@@ -95,6 +95,9 @@ const translationsEnEN = {
     "generalSection.nameOfApp.error": "Upper and lower cased chars and numbers are allowed",
     "generalSection.packageNameOfApp": "Package name",
     "generalSection.packageNameOfApp.error": "Upper and lower cased chars and numbers are allowed",
+
+    "templateSection.loading": "Templates loading...",
+    "templateSection.loading.error": "Templates could not be loaded",
 
     "entityDesigner.code": "Code",
 


### PR DESCRIPTION
## Description
Loads the AppTemplates from Backend instead of a frontend prop.

AB#59

## Motivation and Context
Templates should be loaded from backend

## How has this been tested?
Manually in the browser

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.