### PR TITLE
Feature/ab#58 app entities can be saved per app

### DIFF
--- a/webclient/app/src/app/commons/entityCard/EntityCard.jsx
+++ b/webclient/app/src/app/commons/entityCard/EntityCard.jsx
@@ -1,6 +1,6 @@
 import {Card, Grid, IconButton, Table, TableBody, TableCell, TableHead, TableRow, Typography} from "@mui/material";
 import {Delete, Edit} from "@mui/icons-material";
-import React from "react";
+import React, {useState} from "react";
 import Statement from "../statement/Statement";
 import EntityCardStyles from "./EntityCardStyles";
 import PropTypes from "prop-types";
@@ -9,6 +9,8 @@ import {useTranslation} from "react-i18next";
 function EntityCard(props) {
 
     const entityCardStyles = EntityCardStyles();
+    const [isDeleting, setIsDeleting] = useState(false);
+
     const {entity, handleEdit, handleDelete, editable} = props;
     const {t} = useTranslation();
 
@@ -75,12 +77,19 @@ function EntityCard(props) {
         }
     }
 
-    function renderDeleteClick() {
+    function prepareDelete() {
+        handleDelete(entity.id)
+            .then(setIsDeleting(false))
+            .catch(setIsDeleting(false));
+    }
+
+    function renderDeleteWrapper() {
         if (handleDelete && editable) {
             return (
                 <Grid item sm={2}>
                     <IconButton
-                        onClick={() => handleDelete(entity.id)}
+                        onClick={prepareDelete}
+                        disabled={isDeleting}
                     >
                         <Delete fontSize={"small"}/>
                     </IconButton>
@@ -107,7 +116,7 @@ function EntityCard(props) {
                     {renderTitle(entity.name)}
                 </Grid>
                 {renderEditButton()}
-                {renderDeleteClick()}
+                {renderDeleteWrapper()}
             </Grid>
             {renderFieldsTable(entity)}
         </Card>

--- a/webclient/app/src/app/commons/entityDialog/EntityDialog.jsx
+++ b/webclient/app/src/app/commons/entityDialog/EntityDialog.jsx
@@ -21,12 +21,14 @@ import Statement from "../statement/Statement";
 import {useTranslation} from "react-i18next";
 import ValidatedTextField from "../validatedTextField/ValidatedTextField";
 import RegexConfig from "../../../regexConfig";
+import {LoadingButton} from "@mui/lab";
 
 function EntityDialog(props) {
 
     const [value, setValue] = React.useState(0);
     const [entity, setEntity] = React.useState(null);
     const [hasFormError, setHasFormError] = React.useState(false);
+    const [isSaving, setIsSaving] = React.useState(false);
     const entityEditorStyles = EntityDialogStyles();
     const {t} = useTranslation();
 
@@ -46,12 +48,10 @@ function EntityDialog(props) {
 
         if (!RegexConfig.entityTitle.test(entity.name)) {
             hasError = true;
-            console.log("entityTitleHasError")
         }
 
         entity.fields?.forEach(field => {
             if (!RegexConfig.fieldName.test(field.fieldName)) {
-                console.log(field.name, "has error");
                 hasError = true;
             }
 
@@ -114,9 +114,25 @@ function EntityDialog(props) {
         };
     }
 
+    function prepareSave() {
+
+        setIsSaving(true);
+        handleSave(entity)
+            .then(() => {
+                onClose()
+                setIsSaving(false);
+            })
+            .catch(() => {
+                setIsSaving(false);
+            });
+    }
+
     function addField() {
 
         let newEntity = {...entity};
+        if (!newEntity.fields) {
+            newEntity.fields = [];
+        }
         // TODO Maybe add an ID to entity
         newEntity.fields.push(
             {
@@ -135,6 +151,11 @@ function EntityDialog(props) {
     function addRelationship() {
 
         let newEntity = {...entity};
+
+        if (!newEntity.relationships) {
+            newEntity.relationships = [];
+        }
+
         newEntity.relationships.push(
             {
                 "relationshipType": "",
@@ -272,7 +293,13 @@ function EntityDialog(props) {
                     </TabPanel>
                 </Box>
                 <DialogActions>
-                    <Button onClick={() => handleSave(entity)} disabled={hasFormError}>{t("button.save")}</Button>
+                    <LoadingButton
+                        onClick={prepareSave}
+                        disabled={hasFormError}
+                        loading={isSaving}
+                    >
+                        {t("button.save")}
+                    </LoadingButton>
                 </DialogActions>
             </Container>
         </Dialog>

--- a/webclient/app/src/app/pages/appEditor/AppEditor.jsx
+++ b/webclient/app/src/app/pages/appEditor/AppEditor.jsx
@@ -14,7 +14,6 @@ import {LoadingButton} from "@mui/lab";
 import LoadingSpinner from "../../commons/loadingSpinner/LoadingSpinner";
 
 
-
 function AppEditor() {
 
     const [activeStep, setActiveStep] = useState(0);
@@ -80,6 +79,7 @@ function AppEditor() {
         {
             label: t("appEditor.section.erDesigner.title"),
             component: <ErDesigner
+                appId={appId}
                 entities={entities}
                 handleUpdateEntities={updatedEntities => setEntities(updatedEntities)}
             />,

--- a/webclient/app/src/app/pages/appEditor/sections/erSection/ErSection.jsx
+++ b/webclient/app/src/app/pages/appEditor/sections/erSection/ErSection.jsx
@@ -151,7 +151,7 @@ function ErDesigner(props) {
         })
     }
 
-    function renderAddFab() {
+    function renderAddEntityButton() {
 
         if (!editable) {
             return;
@@ -173,7 +173,7 @@ function ErDesigner(props) {
     }
 
     return (<>
-        {renderAddFab()}
+        {renderAddEntityButton()}
         <div className={erDesignerStyles.codeButtonWrapper}>
             <Button variant={"contained"} startIcon={<Code/>} onClick={openDrawer}>
                 {t("entityDesigner.code")}

--- a/webclient/app/src/app/pages/appEditor/sections/erSection/ErSection.jsx
+++ b/webclient/app/src/app/pages/appEditor/sections/erSection/ErSection.jsx
@@ -22,7 +22,7 @@ function ErDesigner(props) {
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [currentEntity, setCurrentEntity] = useState(false);
     const [coordinates, setCoordinates] = useState([]);
-    const entityRest = useMemo(() => new EntityRest(), [EntityRest]);
+    const entityRest = useMemo(() => new EntityRest(), []);
 
     const {t} = useTranslation();
 

--- a/webclient/app/src/app/services/EntityRest.js
+++ b/webclient/app/src/app/services/EntityRest.js
@@ -1,0 +1,36 @@
+import CrudRest from "./CrudRest";
+import axios from "axios";
+
+class EntityRest extends CrudRest {
+
+    constructor() {
+        super(window.location.pathname + "api/entities");
+    }
+
+    updateEntityByAppId(appId, entity) {
+        return axios.put(this.baseUrl + "/by-app/" + appId, entity);
+    }
+
+    createEntityByApp(appId, entity) {
+        return axios.post(this.baseUrl + "/by-app/" + appId, entity);
+    }
+
+    findAllEntitiesByApp(appId) {
+        return axios.get(this.baseUrl + "/all-by-app/" + appId);
+    }
+
+    updateEntitiesByApp(appId, entities) {
+        return axios.put(this.baseUrl + "/all-by-app/" + appId, entities);
+    }
+
+    createEntitiesByApp(appId, entities) {
+        return axios.post(this.baseUrl + "/all-by-app/" + appId, entities);
+    }
+
+    findEntityByAppIdAndEntityId(appId, entityId) {
+        return axios.get(this.baseUrl + "/by-app/" + appId + "/" + entityId);
+    }
+
+}
+
+export default EntityRest;


### PR DESCRIPTION
## Description
ab#58
Entities will be saved when the Entity dialog is closed

## Motivation and Context
As a user, I will spend a lot of time prototyping the entities. Therefore it is a nice feature to save periodically the progress the use made 

## How has this been tested?
Local
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.