### PR TITLE
Feature/ab#98 data type is not applied to dropdown in fied edit

### DIFF
--- a/webclient/app/src/app/commons/fieldAccordion/FieldAccordion.jsx
+++ b/webclient/app/src/app/commons/fieldAccordion/FieldAccordion.jsx
@@ -77,7 +77,7 @@ function FieldAccordion(props) {
                             <Select
                                 labelId="demo-simple-select-label"
                                 id="demo-simple-select"
-                                value={dataType.name}
+                                value={dataType}
                                 label={t("fieldDialog.dataType")}
                                 onChange={(event) => editFieldProperty("fieldType", event.target.value)}
                             >


### PR DESCRIPTION
## Description
Fixes bug, that the datatype of a field was not correctly shown

## Motivation and Context
Its a bug

## How has this been tested?
Local env
changed select and reopened it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.