### PR TITLE
fix: AB#210 AppEditor: Loading Spinner runns, even if error was returned from backend

### DIFF
--- a/webclient/app/src/app/pages/apps/AppEditor.jsx
+++ b/webclient/app/src/app/pages/apps/AppEditor.jsx
@@ -151,10 +151,14 @@ function AppEditor() {
 
     function handleBack() {
         setIsSaving(true);
-        handleSave().then(() => {
-            setActiveStep((activeStep - 1));
-            setIsSaving(false);
-        });
+        handleSave()
+            .then(() => {
+                setActiveStep((activeStep - 1));
+                setIsSaving(false);
+            })
+            .catch(() => {
+                setIsSaving(false);
+            });
     }
 
     function handleNext() {
@@ -163,7 +167,11 @@ function AppEditor() {
             .then(() => {
                 setActiveStep((activeStep + 1));
                 setIsSaving(false);
-            });
+            })
+            .catch(() => {
+                setIsSaving(false);
+            })
+        ;
     }
 
     function isLastStep() {


### PR DESCRIPTION
## Description
Added catch blocks

## Motivation and Context
If an error happens, the spinner turns further even if the request is done

## How has this been tested?
local env

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.